### PR TITLE
README: correcting begin/end timestamp format

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,8 @@ This service has to be called with the following calll-parameters:
 |  filename |	Name for gif/mp3 file (without extension)   | optional, default=latest  |
 |  format |  `gif` or `mp4` | optional, default='gif'   |
 | exclude  |  list of files to exclude in conversion |optional   |
-| begintimestamp  |  begin timestamp | optional, format 'mm/dd/yyyy hh:mm:ss'   |
-| endtimestamp  | end timestamp  |  optional, format 'mm/dd/yyyy hh:mm:ss'   |
+| begintimestamp  |  begin timestamp | optional, format 'dd/mm/yyyy hh:mm:ss'   |
+| endtimestamp  | end timestamp  |  optional, format 'dd/mm/yyyy hh:mm:ss'   |
 | lasthours  |  Select only files from last x hours since lastfile in selected timerange| optional, Default=0.0 =>select all files in the timerange |
 
 


### PR DESCRIPTION
Correcting `begintimestamp` & `endtimestamp` format to match the Regular Expression test in the code.

I was following the `mm/dd/yyyy hh:mm:ss` format specified in the documentation, but `imagedirector.delete_files` kept failing. It wasn't until I took a screenshot of the error message that I figured out why. The regular expression test was failing because the code wants the day to appear before the month. I have corrected the documentation so that the next person could have better luck.

Error:
> Failed to call service imagedirectory.delete_files. value 02/26/2021 00:00:00 does not match regular expression [0-3][0-9]/[0-1][0-9]/\d{4} [0-2]:[0-5][0-9]:[0-5][0-9] for dictionary value @ data['endtimestamp']